### PR TITLE
Fix global props code sample

### DIFF
--- a/web/app/page.js
+++ b/web/app/page.js
@@ -172,10 +172,7 @@ console.log(hello, "my old friend")`}
                   <span style={{ color: "rgb(199, 146, 234)" }}>lang</span>
                   <span>="</span>
                   <span style={{ color: "rgb(195, 232, 141)" }}>js</span>
-                  <span>" </span>
-                  <span style={{ color: "rgb(199, 146, 234)" }}>
-                    lineNumbers
-                  </span>
+                  <span>"</span>
                 </>
               }
             />


### PR DESCRIPTION
Awesome library :)

I noticed the global props example was passing `lineNumbers` as a prop directly which would mean the `Code.lineNumbers = true` line is redundant. Removing the prop makes the example a bit clearer

Here's how the example looks with the change:

<img width="911" alt="Screen Shot 2023-02-28 at 3 39 03 PM" src="https://user-images.githubusercontent.com/20146550/221739395-7c07ed67-6339-4af2-9a83-52781235bb1c.png">
