### PR TITLE
parseChildren: don't assume className is defined

### DIFF
--- a/.changeset/little-ducks-admire.md
+++ b/.changeset/little-ducks-admire.md
@@ -1,0 +1,5 @@
+---
+"bright": patch
+---
+
+Default to text in md codeblocks

--- a/lib/package.json
+++ b/lib/package.json
@@ -16,7 +16,7 @@
     "watch": "tsup src/index.tsx --format esm,cjs --watch --dts"
   },
   "dependencies": {
-    "@code-hike/lighter": "0.4.1",
+    "@code-hike/lighter": "0.6.2",
     "server-only": "^0.0.1"
   },
   "devDependencies": {

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -173,17 +173,15 @@ function parseChildren(
   if (typeof children === "object" && children?.type === "code") {
     return {
       code: children.props?.children?.trim(),
-      lang: children.props?.className?.replace(
-        "language-",
-        ""
-      ) as LanguageAlias,
+      lang: (children.props?.className?.replace("language-", "") ||
+        "text") as LanguageAlias,
     }
   } else if (typeof children === "object") {
     const subProps = React.Children.toArray(children as any).map((c: any) => {
       const codeProps = c.props?.children?.props
       return {
         code: codeProps.children?.trim(),
-        lang: codeProps.className?.replace("language-", ""),
+        lang: codeProps.className?.replace("language-", "") || "text",
       }
     })
     return {

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -173,14 +173,17 @@ function parseChildren(
   if (typeof children === "object" && children?.type === "code") {
     return {
       code: children.props?.children?.trim(),
-      lang: children.props?.className.replace("language-", "") as LanguageAlias,
+      lang: children.props?.className?.replace(
+        "language-",
+        ""
+      ) as LanguageAlias,
     }
   } else if (typeof children === "object") {
     const subProps = React.Children.toArray(children as any).map((c: any) => {
       const codeProps = c.props?.children?.props
       return {
         code: codeProps.children?.trim(),
-        lang: codeProps.className.replace("language-", ""),
+        lang: codeProps.className?.replace("language-", ""),
       }
     })
     return {

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -50,7 +50,7 @@ export type DoubleTheme = {
 }
 type MdCodeText = {
   type: "code"
-  props: { className: string; children: string }
+  props: { className?: string; children: string }
 }
 
 type MdMultiCodeText = {

--- a/web/app/test-mdx/mdx-demo.mdx
+++ b/web/app/test-mdx/mdx-demo.mdx
@@ -1,5 +1,9 @@
 # Demo
 
+```
+hello
+```
+
 ```jsx
 // title app/page.js
 import { Code } from "bright"

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,10 +237,10 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
-"@code-hike/lighter@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@code-hike/lighter/-/lighter-0.4.1.tgz#65ea4f3011444302b5438e1f99614c57139b680f"
-  integrity sha512-6sYXpIHsklu98o+G8V7TyaxNJrD/2NaHjTIKKqjSRJ/jSY/xo4UNLMEFtMmVAroRmwpLsQVrdChPIsBaNabT8w==
+"@code-hike/lighter@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@code-hike/lighter/-/lighter-0.6.2.tgz#3f5cb79de86878ae0540ea36635591a7d8a82fbb"
+  integrity sha512-yGzUE63b6dRIZFZ5Bn5XKRDsWQSNkGTvYSBZi0lXm2KSI3JKyM32DEns9Oe7aHQF/lf43+r5LjHoBY5K19+Sgw==
 
 "@esbuild/android-arm@0.15.18":
   version "0.15.18"


### PR DESCRIPTION
See #12 for more information. `className` is not always defined with an empty code block:

```
import { MDXRemote } from "next-mdx-remote/rsc";
import { Code } from "bright";

export default function Page() {
  return (
    // @ts-expect-error RSC
    <MDXRemote
      components={{
        pre: Code,
      }}
      source={`\`\`\` 
      
      const hi  MDX \`\`\``}
    />
  );
}
```