### PR TITLE
Correct lineNumberStyle application logic in code.tsx

### DIFF
--- a/.changeset/perfect-geese-compare.md
+++ b/.changeset/perfect-geese-compare.md
@@ -1,0 +1,5 @@
+---
+"bright": patch
+---
+
+Fix line numbers style

--- a/lib/src/code.tsx
+++ b/lib/src/code.tsx
@@ -106,18 +106,17 @@ function Style({
   mode: "dark" | "light" | undefined
   lineNumbers?: boolean
 }) {
-  const lineNumbersStyle = lineNumbers
-    ? ""
-    : `[data-bright-theme] [data-bright-ln] { 
+  const lineNumbersStyle = `[data-bright-theme] [data-bright-ln] { 
     color: var(--line-number-color); 
     margin-right: 1.5ch; 
     display: inline-block;
     text-align: right;
     user-select: none;
   }`
+
   const css = `${displayStyle(mode)}
   [data-bright-theme] ::selection { background-color: var(--selection-background) }
-  ${lineNumbersStyle}
+  ${lineNumbers ? lineNumbersStyle : ""}
   `
   return <style dangerouslySetInnerHTML={{ __html: css }} />
 }


### PR DESCRIPTION
First of all, thank you for creating and sharing such a great library with the community.

This PR aims to address an issue with the reversed application logic of `lineNumberStyle` in the `code.tsx` file. In the original code, the style was applied when `lineNumbers` was falsy, which is incorrect. The proposed changes correct this issue by applying the style only when `lineNumbers` is truthy.

Modified code:
```javascript
  const lineNumbersStyle = `[data-bright-theme] [data-bright-ln] { 
    color: var(--line-number-color); 
    margin-right: 1.5ch; 
    display: inline-block;
    text-align: right;
    user-select: none;
  }`

  const css = `${displayStyle(mode)}
  [data-bright-theme] ::selection { background-color: var(--selection-background) }
  ${lineNumbers ? lineNumbersStyle : ""}
  `
  return <style dangerouslySetInnerHTML={{ __html: css }} />
}
```
Please review and let me know if any further changes are required.