### PR TITLE
fix: Don't aggressively trim code whitespace

### DIFF
--- a/.changeset/twelve-doors-rush.md
+++ b/.changeset/twelve-doors-rush.md
@@ -1,0 +1,6 @@
+---
+"bright": minor
+"bright-web": patch
+---
+
+Don't trim all whitespace

--- a/.changeset/twelve-doors-rush.md
+++ b/.changeset/twelve-doors-rush.md
@@ -1,5 +1,5 @@
 ---
-"bright": minor
+"bright": patch
 "bright-web": patch
 ---
 

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -181,6 +181,10 @@ function runExtensionsBeforeHighlight(props: CodeProps): CodeProps {
   return newProps
 }
 
+function trimTrailingNewlines(code: string | null): string | undefined {
+  return code?.replace(/\n+$/, "") ?? undefined
+}
+
 function parseChildren(
   children: CodeText,
   lang?: LanguageAlias,
@@ -188,14 +192,14 @@ function parseChildren(
 ): Partial<BrightProps> {
   if (typeof children === "object" && children?.type === "code") {
     return {
-      code: children.props?.children?.trim(),
+      code: trimTrailingNewlines(children.props?.children),
       ...getLanguageAndTitle(children.props?.className),
     }
   } else if (typeof children === "object") {
     const subProps = React.Children.toArray(children as any).map((c: any) => {
       const codeProps = c.props?.children?.props
       return {
-        code: codeProps.children?.trim(),
+        code: trimTrailingNewlines(codeProps.children),
         ...getLanguageAndTitle(codeProps.className),
       }
     })

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -181,8 +181,8 @@ function runExtensionsBeforeHighlight(props: CodeProps): CodeProps {
   return newProps
 }
 
-function trimTrailingNewlines(code: string | null): string | undefined {
-  return code?.replace(/\n+$/, "") ?? undefined
+function trimTrailingNewline(code: string | null): string | undefined {
+  return code?.replace(/\n$/, "") ?? undefined
 }
 
 function parseChildren(
@@ -192,14 +192,14 @@ function parseChildren(
 ): Partial<BrightProps> {
   if (typeof children === "object" && children?.type === "code") {
     return {
-      code: trimTrailingNewlines(children.props?.children),
+      code: trimTrailingNewline(children.props?.children),
       ...getLanguageAndTitle(children.props?.className),
     }
   } else if (typeof children === "object") {
     const subProps = React.Children.toArray(children as any).map((c: any) => {
       const codeProps = c.props?.children?.props
       return {
-        code: trimTrailingNewlines(codeProps.children),
+        code: trimTrailingNewline(codeProps.children),
         ...getLanguageAndTitle(codeProps.className),
       }
     })

--- a/web/app/test-mdx/mdx-demo.mdx
+++ b/web/app/test-mdx/mdx-demo.mdx
@@ -71,3 +71,17 @@ console.log(1) // mark[3:10] red
 // mark
 const x = 20
 ```
+
+## Mark code with space
+
+````md
+```
+  here is some text with leading and trailing spaces
+  that is working if the two lines are left-aligned.
+```
+````
+
+```
+  here is some text with leading and trailing spaces
+  that is working if the two lines are left-aligned.
+```

--- a/web/app/test-mdx/mdx-demo.mdx
+++ b/web/app/test-mdx/mdx-demo.mdx
@@ -76,12 +76,20 @@ const x = 20
 
 ````md
 ```
+
+
   here is some text with leading and trailing spaces
   that is working if the two lines are left-aligned.
+
+
 ```
 ````
 
 ```
+
+
   here is some text with leading and trailing spaces
   that is working if the two lines are left-aligned.
+
+
 ```


### PR DESCRIPTION
If code was contained in a nested child (such as when processing markdown) we would previously aggressively `.trim()` the output. Since there can be intentional leading/trailing space in a markdown code block (e.g. for indentation) this is probably too aggressive.

Instead, we now just strip all trailing newlines.

| BEFORE | AFTER |
|-|-|
| <img width="795" alt="SCR-20230718-svhk" src="https://github.com/code-hike/bright/assets/1009/b852d3d4-bc2e-4a01-9674-8bd805e5e619"> | <img width="795" alt="SCR-20230718-svjj" src="https://github.com/code-hike/bright/assets/1009/176ea26c-2bfb-44a8-95c6-20dd263916d6"> |

Fixes https://github.com/code-hike/bright/issues/23