### PR TITLE
Fix issue with MDX inline code

### DIFF
--- a/.changeset/cool-cycles-admire.md
+++ b/.changeset/cool-cycles-admire.md
@@ -1,0 +1,5 @@
+---
+"bright": patch
+---
+
+Fix usage with overriden code element

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -197,7 +197,8 @@ function parseChildren(
     }
   } else if (typeof children === "object") {
     const subProps = React.Children.toArray(children as any).map((c: any) => {
-      const codeProps = c.props?.children?.props
+      const codeProps = c.props?.children?.props ?? c.props
+
       return {
         code: trimTrailingNewline(codeProps.children),
         ...getLanguageAndTitle(codeProps.className),

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -13,6 +13,7 @@ import {
   BrightProps,
   Extension,
   CodeText,
+  MdCodeText,
 } from "./types"
 import { linesToContent } from "./lines"
 import { tokensToContent, tokensToTokenList } from "./tokens"
@@ -190,24 +191,13 @@ function parseChildren(
   lang?: LanguageAlias,
   code?: string
 ): Partial<BrightProps> {
-  if (typeof children === "object" && children?.type === "code") {
-    return {
-      code: trimTrailingNewline(children.props?.children),
-      ...getLanguageAndTitle(children.props?.className),
-    }
-  } else if (typeof children === "object") {
-    const subProps = React.Children.toArray(children as any).map((c: any) => {
-      const codeProps = c.props?.children?.props ?? c.props
+  // the Code component can be used in many ways
+  // this function use some heuristics to guess the correct usage
 
-      return {
-        code: trimTrailingNewline(codeProps.children),
-        ...getLanguageAndTitle(codeProps.className),
-      }
-    })
-    return {
-      subProps,
-    }
-  } else {
+  if (typeof children === "string" || code) {
+    // Basic usage
+    // either: <Code lang="js">console.log(1)</Code>
+    // or: <Code lang="js" code="console.log(1)" />
     let newLang = lang || "text"
     if (!LANG_NAMES.includes(newLang)) {
       console.warn(`Bright warning: Unknown language ${JSON.stringify(lang)}`)
@@ -217,6 +207,46 @@ function parseChildren(
       code: (children as string) || code || "",
       lang: newLang,
     }
+  }
+
+  if (
+    typeof children === "object" &&
+    typeof children?.props?.children === "string"
+  ) {
+    // Basic MDX usage, children usually is <code className="language-js">console.log(1)</code>
+    // the code tag can be replaced by a custom component https://github.com/code-hike/bright/issues/37, so we can't check for the tag name
+    return {
+      code: trimTrailingNewline(children.props?.children),
+      ...getLanguageAndTitle((children as MdCodeText).props?.className),
+    }
+  }
+
+  if (typeof children === "object") {
+    // MDX usage with multiple code blocks (for example: https://bright.codehike.org/recipes/tabs)
+    // children is an array of <Code> components
+    const subProps = React.Children.toArray(children as any).map((c: any) => {
+      const codeElement = c.props?.children
+      const codeProps = codeElement?.props
+
+      return {
+        code: trimTrailingNewline(codeProps.children),
+        ...getLanguageAndTitle(codeProps.className),
+      }
+    })
+    return {
+      subProps,
+    }
+  }
+
+  // unknown usage
+  let newLang = lang || "text"
+  if (!LANG_NAMES.includes(newLang)) {
+    console.warn(`Bright warning: Unknown language ${JSON.stringify(lang)}`)
+    newLang = "text"
+  }
+  return {
+    code: (children as string) || code || "",
+    lang: newLang,
   }
 }
 

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -53,12 +53,12 @@ export type DoubleTheme = {
   dark: Theme
   light: Theme
 }
-type MdCodeText = {
+export type MdCodeText = {
   type: "code"
   props: { className?: string; children: string }
 }
 
-type MdMultiCodeText = {
+export type MdMultiCodeText = {
   type: Function
   props: {
     children: MdCodeText[]


### PR DESCRIPTION
# The problem

When using Bright with MDX, we run into an issue if we try to provide a custom component definition for `<code>`. This issue is described in #31 and #37.

This is an issue because it's common to provide component wrappers around many built-in element types, especially the ones that have Markdown shorthands.

In my case, I want to be able to style inline code elements. For example:

```md
The `VisuallyHidden` component can be used to add fallback text for purely visual elements.
```

# The solution

@jer-k [provided a solution](https://github.com/code-hike/bright/issues/37#issuecomment-1896152229). I forked the repo and tried it out, and it seems to work just fine.

I'd love to see this get merged, if there aren't any concerns on the implementation ♥️. I use this package in my React course, alongside MDX, and I worry that some students will hit this.

Thanks so much for all the work you've done on this package, it's terrific!