### PR TITLE
Fix selectable line numbers in Safari

### DIFF
--- a/lib/src/code.tsx
+++ b/lib/src/code.tsx
@@ -120,6 +120,7 @@ function Style({
     display: inline-block;
     text-align: right;
     user-select: none;
+    -webkit-user-select: none;
   }`
 
   const css = `${displayStyle(mode, lightThemeSelector)}


### PR DESCRIPTION
`user-select` should be used with prefix in Safari https://developer.mozilla.org/en-US/docs/Web/CSS/user-select 