### PR TITLE
Update @code-hike/lighter to 1.0.0

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -16,7 +16,7 @@
     "watch": "tsup src/index.tsx --format esm,cjs --watch --dts"
   },
   "dependencies": {
-    "@code-hike/lighter": "0.8.1",
+    "@code-hike/lighter": "^1.0.0",
     "server-only": "^0.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,10 +237,12 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
-"@code-hike/lighter@0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@code-hike/lighter/-/lighter-0.8.1.tgz#3bde8e1eea3900132359e37c05bae5ac96ddd53c"
-  integrity sha512-St4rPmB7C2EWmAK1sAbvD3lZeM7UDInVDMjQDzEDsu4Q3B3AqF25vXedQK51U0UO0MCOASgBBdTiNwvJAfIqMQ==
+"@code-hike/lighter@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@code-hike/lighter/-/lighter-1.0.0.tgz#05ab87127a060f325fff8ef61748bad19ac6cd30"
+  integrity sha512-GVd0NveUTZ2jgeUh4lrLBZr2zSQT1ws32H747qK6AxSOMas4lXfp5KvkgmsHVg8WLdWwhtaaU9IXpyHEjfeDBw==
+  dependencies:
+    ansi-sequence-parser "1.1.1"
 
 "@esbuild/android-arm@0.15.18":
   version "0.15.18"
@@ -606,6 +608,11 @@ ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-sequence-parser@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
I was trying to use bright to highlight the [gleam](https://github.com/gleam-lang/gleam) language. Everything was in place in `tm-grammars` to do that, bright just needed to be able to access the newer languages. Updating to the latest release of lighter gives us access to the newer version of `tm-grammars`. 

I'm not super familiar with lighter, but it also has a pinned exact version of `tm-grammars`, currently set to `"1.16.2"`. It may be a good idea to relax that requirement so that new languages that get added can be accessed without having to publish newer versions.