### PR TITLE
Add React 19 as a peer dependency

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.9.4"
   },
   "peerDependencies": {
-    "react": "^18"
+    "react": "^18 || ^19"
   }
 }


### PR DESCRIPTION
Hi there!

Now that React 19 is stable, I think Bright should list React 19 as an acceptable peer dependency, otherwise NPM will refuse to install Bright (without `--legacy-peer-deps`).

I don’t know that Bright is _fully_ compatible with React 19, but it seems to work, from what I can see!