### PR TITLE
chore: Add react 19 as peer dep

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.9.4"
   },
   "peerDependencies": {
-    "react": "^18"
+    "react": "^18 || ^19"
   }
 }


### PR DESCRIPTION
Hi,

Love this library. Been using it on my personal page, and I noticed that, the peer deps, are listing React 18 still. This should fix peer deps warnings by package managers.